### PR TITLE
CT-33: Fixing navigation

### DIFF
--- a/credit-tree/src/app/profile/page.client.tsx
+++ b/credit-tree/src/app/profile/page.client.tsx
@@ -73,12 +73,9 @@ export default function Page({ name, email, profile_image }: ProfileProps) {
 
   return (
     <div className={styles.container}>
-      <button
-        className={`fontPacifico ${styles.backButton}`}
-        onClick={() => window.history.back()}
-      >
+      <Link className={`fontPacifico ${styles.backButton}`} href="/tree">
         ⬅
-      </button>
+      </Link>
       <div className={`fontPacifico ${styles.dividerContainer}`}>
         <div className={styles.dividerLine} />
         <div className={`fontPacifico ${styles.divider}`}>Profile</div>

--- a/credit-tree/src/components/info-message/page.module.css
+++ b/credit-tree/src/components/info-message/page.module.css
@@ -6,7 +6,7 @@
   align-items: center;
   bottom: 7.5%;
   user-select: none;
-  z-index: 100;
+  z-index: 101;
 }
 
 .insightMessage {

--- a/credit-tree/src/components/insight-message/page.module.css
+++ b/credit-tree/src/components/insight-message/page.module.css
@@ -6,6 +6,7 @@
   align-items: center;
   bottom: 40%;
   user-select: none;
+  z-index: 100;
 }
 
 .insightMessage {


### PR DESCRIPTION
### CT-33

In #32, I erroneously changed the way that the back button on the Profile page worked. It made the page load quicker, but I misidentified that the user's most previous page would be the `/tree` route, whereas in reality it could have been one of the `/profile/edit` pages.

Also fixed a bug where the insight message would be drawn behind the profile and info buttons.